### PR TITLE
Updated the Formulas Dev Portal Documentation for the httpRequest step

### DIFF
--- a/docs/products/formulas/examples.md
+++ b/docs/products/formulas/examples.md
@@ -205,19 +205,13 @@ Below are some JSON examples of all of the different types of triggers and steps
     "path": {},
     "headers": {},
     "body": "${steps.transform-event.response}",
-    "port": "2222",
-    "api": "/events",
-    "host": "localhost",
-    "scheme": "http"
+    "url": "http://localhost:2222/events"
   }
 }
 ```
 > **NOTE:** The `httpRequest` step is primarily the same as any `request` step with the following exceptions.
 >
-> * The `scheme` indicating whether the request is HTTP or HTTPS is required.
-> * The `host` for the HTTP/S request is required.
-> * The optional `port` may be specified. If the port is omitted, then it defaults to `80` for `HTTP` requests and `443` for `HTTPS` requests.
-> * The `api` attribute is used to specify the `URI` for the `request` invocation. The `api` parameter must start with a leading `/`.
+> * The `url` attribute, with a valid `HTTP` or `HTTPS` URL, is required.
 
 
 ## Example `amqpRequest` steps:

--- a/docs/products/formulas/getting-started.md
+++ b/docs/products/formulas/getting-started.md
@@ -50,11 +50,8 @@ Each different type of step produces different step execution values that are ad
         "query": "{}",
         "body": "{\"Name\":\"New Account Name\"}",
         "method": "POST",
+        "url": "https://api.myservice.com:443/myresource",
         "path": "{}",
-        "scheme": "https",
-        "host": "api.myservice.com",
-        "port": "443",
-        "api": "/myresource",
         "headers": "{\"authorization\":\"mysessionid\",\"content-type\":\"application/json}"
     },
     "response": {
@@ -65,7 +62,7 @@ Each different type of step produces different step execution values that are ad
   }
 }
 ```
-> **Note:** The `scheme` and `host` attributes are required. The supported schemes are `http` and `https`.
+> **Note:** The `url` attribute is required, the value of which must be a valid `http` or `https` URL.
 
 ### `amqpRequest` step:
 ```json


### PR DESCRIPTION
## Highlights
* Replaced the `scheme`, `host`, `port` and `api` URL components with the `url` attribute.
* The change is backwards compatible, i.e., formulas with the above fields will continue to function until they're edited, in which case a value for the `url` attribute will need to be provided.
## Closes
* Closes #152 
