### PR TITLE
Added cross reference links between the ServiceNow and ServiceNow OAuth elements documentation

### DIFF
--- a/docs/elements/servicenow-oauth/index.md
+++ b/docs/elements/servicenow-oauth/index.md
@@ -13,13 +13,18 @@ sitemap: false
 
 ## Welcome to the ServiceNow OAuth Element
 
+The ServiceNow OAuth element, as the name suggests, uses `OAuth 2.0` based authentication.
+
+__Note:__ If you're looking for the ServiceNow element with `Basic` authentication, please visit the [ServiceNow](/docs/elements/servicenow/) documentation.
+
 
 #### At a Glance
 
 In order to create a connection to ServiceNow OAuth the following steps are required:
 
 1. Retrieve your ServiceNow OAuth Username, Password, Client ID, Client Secret, and Subdomain URL when you register your connected app
-2. Call the `POST /instances` API to instantiate your ServiceNow OAuth connected app
+2. Use the OAuth authentication flow as shown [here](/docs/getstarted/authentication.html) to complete the authentication and then,
+3. Call the `POST /instances` API to instantiate your ServiceNow OAuth connected app
 
 #### In Depth
 

--- a/docs/elements/servicenow/index.md
+++ b/docs/elements/servicenow/index.md
@@ -13,15 +13,18 @@ sitemap: false
 
 ## Welcome to the ServiceNow Element
 
+The ServiceNow element uses `Basic` authentication, i.e., authentication with a username, password and your ServiceNow sub-domain URL.
 
-#### At a Glance
+__Note:__ If you're looking for the ServiceNow element with OAuth based authentication, please visit the [ServiceNow OAuth](/docs/elements/servicenow-oauth/) documentation.
+
+### At a Glance
 
 In order to create a connection to ServiceNow the following steps are required:
 
 1. Retrieve your ServiceNow Username, Password, and Subdomain URL
 2. Call the `POST /instances` API to instantiate your ServiceNow connected app
 
-#### In Depth
+### In Depth
 
 The ServiceNow Element is a collection of resources providing a pre-built integration into a service endpoint. RESTful methods (POST, GET, PUT, PATCH, DELETE) are used to interact with these resources (accounts, contacts, files) regardless of the type of APIs (SOAP or REST) provided by the endpoint. Elements leverage Cloud Elements API Manager platform services including authentication, data transformation, and event management.  The API is built to allow you to create a functional application or integration quickly and easily.
 


### PR DESCRIPTION
## Highlights
* Cloud Elements support two elements for ServiceNow, one that uses the ServiceNow API with Basic authentication, and the other that uses the API with OAuth.
* In order to allow users to ensure that they easily find the correct documentation they're looking for, links have been added to each of the above element's documentation that references the other element.

## Closes
* Closes #242 
