### PR TITLE
Remove elementInstanceId from HTTP Request json example

### DIFF
--- a/docs/guides/formulasC2/referenceAPI.md
+++ b/docs/guides/formulasC2/referenceAPI.md
@@ -326,7 +326,6 @@ The HTTP Request (`httpRequest`) step make an HTTP/S call to any URL/endpoint.
   "onFailure": [],
   "type": "httpRequest",
   "properties": {
-    "elementInstanceId": "${config.elementVariable}",
     "method": "POST",
     "url": "https://mycoolapp.com/api",
     "headers": "Header content",


### PR DESCRIPTION
## Highlights
* Similar to #1185, remove `elementInstanceId` from HTTP Request. This time in the JSON.
