### PR TITLE
ENG-1997 - Updated the code to use kramdown instead of redcarpet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rake'
 group :jekyll_plugins do
   gem 'algoliasearch-jekyll', '~> 0.8.0'
   gem 'jekyll-redirect-from'
-  gem 'redcarpet'
+  gem 'kramdown'
   gem 'jekyll-youtube'
   gem 'html-proofer'
   gem 'jekyll-paginate'

--- a/_config.yml
+++ b/_config.yml
@@ -8,11 +8,19 @@ exclude:
 liquid:
   error_mode: strict
 
-markdown: redcarpet
+markdown: kramdown
 markdown_ext: markdown,mkdown,mkdn,mkd,md
 
-redcarpet:
-  extensions: ["tables", "autolink", "strikethrough", "space_after_headers", "with_toc_data", "fenced_code_blocks"]
+kramdown:
+    input: GFM
+    syntax_highligher: true
+    syntax_highlighter_opts:
+        line_numbers: true
+    auto_ids:      true
+    footnote_nr:   1
+    entity_output: as_char
+    toc_levels:    1..6
+    smart_quotes:  lsquo,rsquo,ldquo,rdquo
 
 url: https://developers.cloud-elements.com
 


### PR DESCRIPTION
## Highlights
* The newer version of `jekyll` does not support `redcarpet`, so updated the configuration to use `kramdown` instead

## Closes
* Closes #ENG-1997
